### PR TITLE
bug in generating the variants

### DIFF
--- a/src/deanon/Deanon.java
+++ b/src/deanon/Deanon.java
@@ -657,7 +657,7 @@ public class Deanon
 					log("\t\t\tnode overlap: "+common_vertices.size());
 				}
 			}
-			if(args[5].equals("sample"))
+			else if(args[5].equals("sample"))
 			{
 				for(int j = 0; j < Integer.parseInt(args[6]); j++)
 				{


### PR DESCRIPTION
A cloning variant was always invoked and the related export used to overwrite the previous one